### PR TITLE
Bump pyproject and add dep to polars to read from cloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 dependencies = [
     "pandas==2.2.2",
-    "polars[pyarrow]== 1.8.2",
+    "polars[pyarrow,fsspec]== 1.14.0",
     "scikit-learn==1.5.2",
     "requests==2.32.3",
     "plotly==5.24.1",

--- a/src/vcub_keeper/production/data.py
+++ b/src/vcub_keeper/production/data.py
@@ -85,7 +85,7 @@ def transform_json_station_data_to_df(station_json: dict) -> pl.LazyFrame:
 
     # Status mapping
     status_dict = {"open": 1, "closed": 0}
-    station_df = station_df.with_columns(status=pl.col("status").replace(status_dict, default=0).cast(pl.UInt8))
+    station_df = station_df.with_columns(status=pl.col("status").replace_strict(status_dict, default=0).cast(pl.UInt8))
 
     # Naming
     station_df = station_df.rename({"id": "station_id", "ts": "date"})
@@ -234,7 +234,7 @@ def transform_json_api_bdx_station_data_to_df(station_json: dict) -> pl.LazyFram
 
     # Status mapping
     status_dict = {"CONNECTEE": 1, "DECONNECTEE": 0, "MAINTENANCE": 0}
-    station_df = station_df.with_columns(status=pl.col("status").replace(status_dict, default=0).cast(pl.UInt8))
+    station_df = station_df.with_columns(status=pl.col("status").replace_strict(status_dict, default=0).cast(pl.UInt8))
 
     station_df = station_df.with_columns(station_id=pl.col("station_id").cast(pl.Int32()))
     station_df = station_df.with_columns(

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -39,7 +39,7 @@ Geo Point;Geo Shape;commune;IDENT;TYPE;NOM;NBPLACES;NBVELOS
 
     expected_df = pl.DataFrame(expected_data)
 
-    assert_frame_equal(stations, expected_df, check_dtype=False)
+    assert_frame_equal(stations, expected_df, check_dtypes=False)
 
 
 def test_read_stations_attributes():
@@ -75,7 +75,7 @@ Geo Point;Geo Shape;COMMUNE;total_stand;NOM;TYPEA;station_id;lat;lon
 
     expected_df = pl.DataFrame(expected_data)
 
-    assert_frame_equal(stations, expected_df, check_dtype=False)
+    assert_frame_equal(stations, expected_df, check_dtypes=False)
 
 
 def test_create_breakpoints_to_use_cut():


### PR DESCRIPTION
- Bump polars version `1.8.2` to `1.14.0`.
- Add dep's polars to read from cloud.

Some Deprecated warning fix : 
- `replace` -> `Deprecated`.
- `check_dtype` -> `check_dtypes`.